### PR TITLE
fix(#2): Spring returns 403 on exception

### DIFF
--- a/todo_backend/src/main/java/dev/oskarwiedeweg/todo_backend/security/SecurityConfig.java
+++ b/todo_backend/src/main/java/dev/oskarwiedeweg/todo_backend/security/SecurityConfig.java
@@ -29,6 +29,8 @@ public class SecurityConfig {
         http.csrf().disable();
 
         http.authorizeHttpRequests()
+                .requestMatchers("/error")
+                .permitAll()
                 .requestMatchers("/api/v1/auth/**")
                 .permitAll()
                 .anyRequest()


### PR DESCRIPTION
The security context gets cleared on the error page creation, but we don't allow unauthorized requests to anything other than `/api/v1/auth`.

This happens, because the security context is thread based. It gets cleared so we don't accidentally assign a wrong identity to a different user.